### PR TITLE
Cookie and headers logic fixes

### DIFF
--- a/dist/hapi-i18next.js
+++ b/dist/hapi-i18next.js
@@ -44,7 +44,7 @@ exports.register = function (server, options, next) {
     });
     i18n.init(i18nextOptions);
     server.ext('onPreHandler', function (request, reply) {
-        var translations = {}, headerLang, fromPath, language, temp, cookieLang;
+        var translations = {}, headerLang, fromPath, language, temp;
         if (!language && typeof i18nextOptions.detectLngFromPath === 'number') {
             // if force is true, then we set lang even if it is not in supported languages list
             temp = detectLanguageFromPath(request);
@@ -69,13 +69,11 @@ exports.register = function (server, options, next) {
             }
         }
         language = language || i18n.lng();
-        cookieLang = request.state[i18nextOptions.cookieName];
-        if (!cookieLang || cookieLang !== language) {
-            // set the language cookie
-            reply.state(i18nextOptions.cookieName, language);
-        }
         if (language !== i18n.lng()) {
             i18n.setLng(language, function () {
+                if (i18nextOptions.useCookie) {
+                    reply.state(i18nextOptions.cookieName, language);
+                }
                 reply.continue();
             });
             return;
@@ -120,5 +118,5 @@ exports.register = function (server, options, next) {
 };
 exports.register.attributes = {
     name: 'hapi-i18next',
-    version: '2.0.1'
+    version: '2.0.2'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-i18next",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "hapijs plugin for i18next",
   "main": "index.js",
   "directories": {

--- a/src/hapi-i18next.ts
+++ b/src/hapi-i18next.ts
@@ -63,8 +63,7 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 			headerLang: any,
 			fromPath: string,
 			language: string,
-			temp: string,
-			cookieLang: string;
+			temp: string;
 
 		if (!language && typeof i18nextOptions.detectLngFromPath === 'number') {
 			// if force is true, then we set lang even if it is not in supported languages list
@@ -95,13 +94,11 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 
 		language = language || i18n.lng();
 
-		cookieLang = request.state[i18nextOptions.cookieName];
-		if (!cookieLang || cookieLang !== language) {
-			// set the language cookie
-			reply.state(i18nextOptions.cookieName, language);
-		}
 		if (language !== i18n.lng()) {
 			i18n.setLng(language, () => {
+				if (i18nextOptions.useCookie) {
+					reply.state(i18nextOptions.cookieName, language);
+				}
 				reply.continue();
 			});
 			return;
@@ -157,5 +154,5 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 
 register.attributes = {
 	name: 'hapi-i18next',
-	version: '2.0.1'
+	version: '2.0.2'
 };

--- a/src/hapi-i18next.ts
+++ b/src/hapi-i18next.ts
@@ -63,7 +63,8 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 			headerLang: any,
 			fromPath: string,
 			language: string,
-			temp: string;
+			temp: string,
+			cookieLang: string;
 
 		if (!language && typeof i18nextOptions.detectLngFromPath === 'number') {
 			// if force is true, then we set lang even if it is not in supported languages list
@@ -82,23 +83,23 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 			// Reads language if it was set from previous session or recently by client
 			temp = detectLanguageFromCookie(request);
 			language = trySetLanguage(temp);
-
-			if (!request.state[i18nextOptions.cookieName] || request.state[i18nextOptions.cookieName] !== language) {
-				// if no set cookie is set
-				reply.state(i18nextOptions.cookieName, language || i18n.lng());
-			}
 		}
 
 		if (!language && i18nextOptions.detectLngFromHeaders) {
 			headerLang = detectLanguageFromHeaders(request);
 			if (headerLang.length) {
-				temp = headerLang[0].code + (headerLang.region ? '-' + headerLang.region : '');
+				temp = headerLang[0].code + (headerLang[0].region ? '-' + headerLang[0].region : '');
 				language = trySetLanguage(temp);
 			}
 		}
 
 		language = language || i18n.lng();
 
+		cookieLang = request.state[i18nextOptions.cookieName];
+		if (!cookieLang || cookieLang !== language) {
+			// set the language cookie
+			reply.state(i18nextOptions.cookieName, language);
+		}
 		if (language !== i18n.lng()) {
 			i18n.setLng(language, () => {
 				reply.continue();
@@ -131,7 +132,7 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 			});
 			return langs;
 		}
-		
+
 		return [];
 	}
 
@@ -158,4 +159,3 @@ register.attributes = {
 	name: 'hapi-i18next',
 	version: '2.0.1'
 };
-


### PR DESCRIPTION
Fixing cookie setting logic to take headers into account before setting the cookies. Also, fixing support for language codes with dashes in them retrieved from headers. I.e. `en-us` or `pt-br`
