### PR TITLE
Fixed: language detection from the HTTP headers

### DIFF
--- a/src/hapi-i18next.ts
+++ b/src/hapi-i18next.ts
@@ -120,7 +120,10 @@ export var register: HapiPluginRegister = function (server, options: any, next):
 			langs.sort((a, b) => {
 				return b.q - a.q;
 			});
-			return langs;
+			
+			return langs.map((lang) => {
+				return lang.code;
+			});
 		}
 
 		return [];


### PR DESCRIPTION
Hi,
I've noticed that the `accept-language` header is not parsed correctly.
The problem is in the return value of `detectLanguageFromHeaders` where each object in the array returned by `acceptLanguageParser.parse` should be mapped to a language code.
